### PR TITLE
Create child wraps using type(self)

### DIFF
--- a/tortilla/wrappers.py
+++ b/tortilla/wrappers.py
@@ -358,7 +358,7 @@ class Wrap(object):
 
     def _get_or_create_child_wrap(self, name):
         if name not in self._children:
-            self._children[name] = Wrap(
+            self._children[name] = self.__class__(
                 part=name,
                 parent=self,
                 debug=self.config.get('debug'),


### PR DESCRIPTION
Hi,
I think it would be nice to use `type(self)` in the `_get_or_create_child_wrap` method. This way subclasses of `Wrap` will return instances of the current subclass.