### PR TITLE
docs: fix simple typo, trailling -> trailing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -178,13 +178,13 @@ This option can be overridden with every request or subwrap:
 URL Suffix
 ~~~~~~~~~~
 
-Some APIs uses a trailling slash at the end of URLs like in example below:
+Some APIs uses a trailing slash at the end of URLs like in example below:
 
 .. code-block:: text
 
     https://api.example.org/resource/
 
-You can add the trailling slash with ``suffix="/"`` argument when wrapping
+You can add the trailing slash with ``suffix="/"`` argument when wrapping
 the API or getting the URL with ``.url(suffix="/")`` method:
 
 .. code-block:: python


### PR DESCRIPTION
There is a small typo in README.rst.

Should read `trailing` rather than `trailling`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md